### PR TITLE
Rebuild for shaderc 2026.2 and correct run_exports

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,11 +23,13 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -104,7 +106,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
     - shaderc
     - xxhash
   run_exports:
-    - ${{ pin_subpackage('libplacebo', upper_bound='x.x.x') }}
+    - ${{ pin_subpackage('libplacebo', upper_bound='x.x') }}
   ignore_run_exports:
     from_package:
       - xxhash

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 4efe1c8d4da3c61295eb5fdfa50e6037409d8425eb3c15dd86788679c4ce59ee
 
 build:
-  number: 2
+  number: 3
   skip: win
 
 requirements:


### PR DESCRIPTION
See the first point in https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/8450 . While I was at it, I also corrected the run_exports's upper_bound. The library soversion is the minor version (see https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Flibplacebo-7.351.0-h9eeb4b2_2.conda) and all patch releases do not modify the ABI (see https://github.com/haasn/libplacebo/compare/v6.338.0...v6.338.1, https://github.com/haasn/libplacebo/compare/v6.338.1...v6.338.2 and https://github.com/haasn/libplacebo/compare/v7.360.0...v7.360.1) so I think it makes more sense to have `upper_bound='x.x'` in place of `upper_bound='x.x.x'`

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
