### PR TITLE
update to v7.360.1 & rebase on github mirror

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -44,10 +44,14 @@ requirements:
 
 tests:
   - package_contents:
+      include:
+        - libplacebo/**
       lib:
         - libplacebo
+      files:
+        - lib/pkgconfig/libplacebo.pc
   - script:
-      - if pkg-config --exists libplacebo; then echo "Libplacebo found"; else echo "Libplacebo not found"; exit 1; fi
+      - pkg-config --exists libplacebo
     requirements:
       run:
         - pkg-config

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,7 @@
 context:
   name: libplacebo
   version: "7.360.1"
+  build_number: 0
 
 package:
   name: ${{ name|lower }}
@@ -11,27 +12,28 @@ source:
   sha256: d05fdf90bea2f629eaa2d115e909fd356388ac639e54f77b87a018a6d76224bd
 
 build:
-  number: 0
-  skip: win
+  number: ${{ build_number }}
+  skip:
+    - win
 
 requirements:
   build:
-    - ${{ compiler('c') }}
-    - ${{ stdlib('c') }}
-    - ${{ compiler('cxx') }}
-    - ninja
     - cmake
-    - pkg-config
-    - meson
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
     - jinja2
+    - meson
+    - ninja
+    - pkg-config
     - python <3.13 # pins python to compatible version for meson
   host:
-    - libdovi
     - fast_float
     - lcms2
-    - markupsafe
+    - libdovi
     - libvulkan-headers
     - libvulkan-loader
+    - markupsafe
     - shaderc
     - xxhash
   run_exports:
@@ -59,6 +61,7 @@ about:
     mpv rewritten as an independent library. It provides robust and efficient
     GPU rendering for a variety of multimedia applications.
   homepage: https://code.videolan.org/videolan/libplacebo
+  repository: https://code.videolan.org/videolan/libplacebo
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,17 +1,17 @@
 context:
   name: libplacebo
-  version: "7.351.0"
+  version: "7.360.1"
 
 package:
   name: ${{ name|lower }}
   version: ${{ version }}
 
 source:
-  url: https://code.videolan.org/videolan/libplacebo/-/archive/v${{ version }}/libplacebo-v${{ version }}.tar.gz
-  sha256: 4efe1c8d4da3c61295eb5fdfa50e6037409d8425eb3c15dd86788679c4ce59ee
+  url: https://github.com/haasn/libplacebo/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d05fdf90bea2f629eaa2d115e909fd356388ac639e54f77b87a018a6d76224bd
 
 build:
-  number: 3
+  number: 0
   skip: win
 
 requirements:


### PR DESCRIPTION
- rebase from gitlab to github mirror to have support for the regor-cf bot aut updates.

- bump to version v7.360.1

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
